### PR TITLE
Update package.json with oidc-client-ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "react-router-dom": "^6.21.3",
     "react-scripts": "5.0.1",
     "typescript": "^4.4.2",
-    "web-vitals": "^2.1.0"
+    "web-vitals": "^2.1.0",
+    "oidc-client-ts": "^2.4.0",
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Dependency was missing. 'yarn add' does not help because it adds the latest version of oidc-client-ts, which is not backward compatible with 2.4.0