### PR TITLE
fix: make `loadUserInfo` configurable instead of hardcoded

### DIFF
--- a/lib/src/zitadelAuth.ts
+++ b/lib/src/zitadelAuth.ts
@@ -40,7 +40,7 @@ export function createZitadelAuth(zitadelConfig: ZitadelConfig): ZitadelAuth {
 
   const userManager = new UserManager({
     userStore: new WebStorageStateStore({ store: window.localStorage }),
-    loadUserInfo: true,
+    loadUserInfo: zitadelConfig.loadUserInfo ?? true,
     ...authConfig,
   });
 


### PR DESCRIPTION
## Summary

- Allow users to configure `loadUserInfo` option instead of hardcoding it to `true`
- Maintain backward compatibility by defaulting to `true` when not specified

## Problem

The `loadUserInfo` option was hardcoded to `true`, preventing users from disabling the userinfo endpoint call even when they have "User Info inside ID Token" enabled in their ZITADEL application settings.

Fixes #46 

## Changes

- Modified `createZitadelAuth()` to use `zitadelConfig.loadUserInfo ?? true` instead of hardcoded `true`