### PR TITLE
test: cover project-scoped role claim

### DIFF
--- a/test/hasRole.test.ts
+++ b/test/hasRole.test.ts
@@ -30,6 +30,19 @@ describe('hasRole', () => {
     expect(hasRole(user, 'editor')).toBe(false);
   });
 
+  it('should return true for project-scoped role claims', () => {
+    const user = {
+      profile: {
+        sub: 'user-1',
+        'urn:zitadel:iam:org:project:306217913633734659:roles': {
+          admin: { '306130699507728387': 'my-org.localhost' },
+        },
+      },
+    } as unknown as User;
+
+    expect(hasRole(user, 'admin')).toBe(true);
+  });
+
   it('should return false when there is no user', () => {
     expect(hasRole(null, 'admin')).toBe(false);
   });


### PR DESCRIPTION
Adds a regression test for the project-scoped role claim form `urn:zitadel:iam:org:project:<id>:roles`, asserting `hasRole` resolves the role. Mirrors the same coverage added across the auth library family.